### PR TITLE
ChatSpace 自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function(){
   function buildHTML(message){
     if ( message.image ) {
       var html =
-       `<div class="main-chat__message-list__items__message">
+       `<div class="main-chat__message-list__items__message" data-message-id=${message.id}>
           <div class="main-chat__message-list__items__message__upper-info">
             <div class="main-chat__message-list__items__message__upper-info__talker">
               ${message.user_name}
@@ -21,7 +21,7 @@ $(function(){
       return html;
     } else {
       var html =
-       `<div class="main-chat__message-list__items__message">
+       `<div class="main-chat__message-list__items__message" data-message-id=${message.id}>
           <div class="main-chat__message-list__items__message__upper-info">
             <div class="main-chat__message-list__items__message__upper-info__talker">
               ${message.user_name}
@@ -39,6 +39,7 @@ $(function(){
       return html;
     };
   }
+
   $('#new_message').on('submit', function(e){
     e.preventDefault();
     var formData = new FormData(this);
@@ -64,4 +65,29 @@ $(function(){
       $('.main-chat__message-form__input-box__send-btn').prop('disabled', false);
     });
   });
+    var reloadMessages = function() {
+      var last_message_id = $('.main-chat__message-list__items__message:last').data("message-id");
+      $.ajax({
+        url: "api/messages",
+        type: 'get',
+        dataType: 'json',
+        data: {id: last_message_id}
+      })
+      .done(function(messages) {
+        if (messages.length !== 0) {
+          var insertHTML = '';
+          $.each(messages, function(i, message) {
+            insertHTML += buildHTML(message)
+          });
+          $('.main-chat__message-list').append(insertHTML);
+          $('.main-chat__message-list').animate({ scrollTop: $('.main-chat__message-list')[0].scrollHeight});
+        }
+      })
+      .fail(function() {
+        alert('error');
+      });
+    };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -48,6 +48,7 @@
     background-color: #2f3e51;
     height: calc(100vh - 100px);
     padding: 20px 0;
+    overflow: scroll;
     &__items__groups {
       height: 91px;
       background-color: #2f3e51;

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.main-chat__message-list__items__message
+.main-chat__message-list__items__message{data: {message: {id: message.id}}}
   .main-chat__message-list__items__message__upper-info
     .main-chat__message-list__items__message__upper-info__talker
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,5 @@
-json.user_name @message.user.name
+json.content    @message.content
+json.image      @message.image.url
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-json.content @message.content
-json.image @message.image_url
+json.user_name @message.user.name
+json.id @message.id


### PR DESCRIPTION
# What
下記の機能を実装
①表示されているメッセージのidを追加
②新規投稿を取得
　・新規メッセージ確認用のアクションを追加
　・アクションを呼び出せるようルーティングを追加
③投稿内容をレスポンスする
④取得した投稿データを表示する
　・取得した最新のメッセージをブラウザのメッセージ一覧に追加
　・数秒ごとにリクエストするように実装
　・メッセージを取得したら画面がスクロールする
　・自動更新が必要ない画面では行わない

# Why
ChatSpaceに自動更新機能を実装するため

# GIF
https://gyazo.com/b1445102e7015318b1c5946199aa14ea